### PR TITLE
support 1080p bilibili videos without cookies

### DIFF
--- a/src/streamfinder/bilibili.rs
+++ b/src/streamfinder/bilibili.rs
@@ -268,6 +268,9 @@ impl Bilibili {
             param1.push(("cid", cid.as_str()));
             param1.push(("bvid", bvid.as_str()));
             param1.push(("fnval", "3024"));
+            if cookies.is_empty() {
+                param1.push(("try_look", "1"));
+            }
             let client = reqwest::Client::builder()
                 .user_agent(crate::utils::gen_ua_safari())
                 .connect_timeout(tokio::time::Duration::from_secs(10))


### PR DESCRIPTION
I didn't bother to add this parameter for `BVideoType::Bangumi` type of videos, because relevant code seems broken already:

```ShellSession
$ dmlive -u https://www.bilibili.com/bangumi/play/ep508404
[2023-11-22T03:26:45Z WARN  dmlive::streamfinder] real url not found, retry...
[2023-11-22T03:26:48Z WARN  dmlive::streamfinder] real url not found, retry...
[2023-11-22T03:26:52Z WARN  dmlive::streamfinder] real url not found, retry...
```

I learned about this parameter in <https://github.com/nilaoda/BBDown/blob/1196918e709f883eabfe3122ccad824b8f551381/BBDown.Core/Parser.cs#L63>.