### PR TITLE
fix bilibili video real url parsing when dash.flac.audio is null

### DIFF
--- a/src/streamfinder/bilibili.rs
+++ b/src/streamfinder/bilibili.rs
@@ -246,7 +246,7 @@ impl Bilibili {
                     ul.iter().find(|&&x| !x.contains("mcdn")).ok_or_else(|| dmlerr!())?.to_string(),
                 );
             }
-            if let Some(ele) = j.pointer("/dash/flac/audio") {
+            if let Some(ele) = j.pointer("/dash/flac/audio").filter(|x| !x.is_null()) {
                 let mut ul = Vec::new();
                 ul.push(ele.pointer("/base_url").and_then(|x| x.as_str()).ok_or_else(|| dmlerr!())?);
                 ele.pointer("/backup_url")


### PR DESCRIPTION
Some videos return `"flac": {"display": true, "audio": null}` from the playurl API (Hi-Res flagged but no flac stream for the current account). `pointer("/dash/flac/audio")` gives `Some(Null)` in that case, so parsing fails and dmlive loops on "real url not found".